### PR TITLE
docs: docs link goes to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ If you have an account with Sauce Labs, you can run the automated tests of this 
    
 ## Have a Question? Found a bug?
 
-[Reach out to us](https://docs.deque.com/devtools-mobile/2023.8.16/en/help), we'd love to help!
+[Reach out to us](https://docs.deque.com/devtools-mobile/help), we'd love to help!


### PR DESCRIPTION
Changes the docs URL so that it goes to the latest version of the docs.