### PR TITLE
chore: Update the library version April 2025 release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
 
     //Deque AxeDevtoolsAndroid library
-    implementation 'com.deque.android:axe-devtools-android:6.2.0'
+    implementation 'com.deque.android:axe-devtools-android:6.3.0'
 
     implementation 'androidx.activity:activity-compose:1.8.0'
     implementation platform('androidx.compose:compose-bom:2023.03.00')


### PR DESCRIPTION
The pr updates the library in the sample app to the latest released version 6.3.0. 

Verified working with [this scan](https://axe-mobile.deque.com/scan?userId=3706a305-322a-4fe4-83a0-c0c1d567764d&packageName=com.deque.mobile.axedevtoolssampleapp&resultId=0196ee19-87cf-75ba-84f8-6129ca9e8d37)