### PR TITLE
chore: Update ADT library version July 16, 2025 patch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
 
     //Deque AxeDevtoolsAndroid library
-    androidTestImplementation 'com.deque.android:axe-devtools-android:7.0.0'
+    androidTestImplementation 'com.deque.android:axe-devtools-android:7.0.1'
 
     // MLKit implementation for use with ADT Library
     implementation 'com.google.mlkit:text-recognition:16.0.1'


### PR DESCRIPTION
This pr updates the version of the library used in the sample app for the patch release