### PR TITLE
added navcontroller logic to main activity to maintain status on scre…

### DIFF
--- a/app/src/main/java/com/deque/mobile/axedevtoolssampleapp/MainActivity.kt
+++ b/app/src/main/java/com/deque/mobile/axedevtoolssampleapp/MainActivity.kt
@@ -2,19 +2,36 @@ package com.deque.mobile.axedevtoolssampleapp
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.NavigationUI.setupWithNavController
+import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity() {
 
+    private lateinit var navController: NavController
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // Find the NavHostFragment using its ID. This is the recommended way to
+        // retrieve the NavController in an Activity.
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.nav_host_fragment_container) as NavHostFragment
-        val navController = navHostFragment.navController
+        navController = navHostFragment.navController
+
+        // Find the BottomNavigationView
         val bottomNav: BottomNavigationView = findViewById(R.id.bottom_nav_bar)
-        setupWithNavController(bottomNav, navController)
+
+        // Set up the BottomNavigationView with the NavController.
+        // This will automatically handle navigation when bottom nav items are tapped
+        // and correctly update the selected item when navigating.
+        bottomNav.setupWithNavController(navController)
+    }
+
+    // It's good practice to also handle the Up button correctly with your NavController.
+    override fun onSupportNavigateUp(): Boolean {
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 }


### PR DESCRIPTION
with the XML Compose home screen, when you proceed into the main screens of the app, if you rotate the screen, the main activity was not maintaining it's status - and therefore the app was being returned to the launcher screen.

The impact of this is in for example test automation when axe:scan was called with the screen rotation test, the test automation never proceeded to the next step because the app was always returning to the launcher screen.

The fix I implemented here restores the pre-rotation status such that the test automation can proceed normally and will make for better pre-sales demos.